### PR TITLE
Updating Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The plugin is available as a Python package in pypi and can be installed with pi
 pip install nautobot-plugin-capacity-metrics
 ```
 
-> The plugin is compatible with Nautobot 2.8.1 and higher
+> The plugin is compatible with Nautobot 1.0.0 and higher
 
 To ensure Application Metrics Plugin is automatically re-installed during future upgrades, create a file named `local_requirements.txt` (if not already existing) in the Nautobot root directory (alongside `requirements.txt`) and list the `nautobot-plugin-capacity-metrics` package:
 

--- a/nautobot_capacity_metrics/__init__.py
+++ b/nautobot_capacity_metrics/__init__.py
@@ -1,6 +1,6 @@
 """Plugin declaration for nautobot_capacity_metrics."""
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 from nautobot.extras.plugins import PluginConfig
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-capacity-metrics"
-version = "1.0.1"
+version = "1.0.2"
 description = "Plugin to improve the instrumentation of Nautobot and expose additional metrics (Application Metrics, RQ Worker)."
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-nautobot = "*"
+# Used for local development
+nautobot = { version = "*", optional = true }
 
 [tool.poetry.dev-dependencies]
 black = "*"


### PR DESCRIPTION
Fixes: #11 

If someone has Nautobot 1.0.1 installed, and they add this plugin as a dependency using poetry it is possible to end up in a case where the plugin requirements will force a downgrade of the Nautobot package itself.  We don't want that.