### PR TITLE
fix: corrected docs typos & errors

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -155,15 +155,15 @@ To enable this mode the environment variable `prometheus_multiproc_dir` must be 
 
 The plugin is available as a Python package in pypi and can be installed with pip
 ```shell
-pip install nautobot-plugin-capacity-metrics
+pip install nautobot-capacity-metrics
 ```
 
-> The plugin is compatible with Nautobot 2.8.1 and higher
+> The plugin is compatible with Nautobot 1.0.0 and higher (or Netbox 2.8.1 and higher)
 
-To ensure Application Metrics Plugin is automatically re-installed during future upgrades, create a file named `local_requirements.txt` (if not already existing) in the Nautobot root directory (alongside `requirements.txt`) and list the `nautobot-plugin-capacity-metrics` package:
+To ensure Application Metrics Plugin is automatically re-installed during future upgrades, create a file named `local_requirements.txt` (if not already existing) in the Nautobot root directory (alongside `requirements.txt`) and list the `nautobot-capacity-metrics` package:
 
 ```no-highlight
-# echo nautobot-plugin-capacity-metrics >> local_requirements.txt
+# echo nautobot-capacity-metrics >> local_requirements.txt
 ```
 
 Once installed, the plugin needs to be enabled in your `configuration.py`
@@ -180,9 +180,8 @@ PLUGINS = ["nautobot_capacity_metrics"]
 #        },
 #        "jobs": True,
 #        "queues": True,
-#       }
-#     }
-#   }
+#      }
+#    }
 # }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -158,7 +158,7 @@ The plugin is available as a Python package in pypi and can be installed with pi
 pip install nautobot-capacity-metrics
 ```
 
-> The plugin is compatible with Nautobot 1.0.0 and higher (or Netbox 2.8.1 and higher)
+> The plugin is compatible with Nautobot 1.0.0 and higher
 
 To ensure Application Metrics Plugin is automatically re-installed during future upgrades, create a file named `local_requirements.txt` (if not already existing) in the Nautobot root directory (alongside `requirements.txt`) and list the `nautobot-capacity-metrics` package:
 


### PR DESCRIPTION
Hi, as I was working with this plugin I came across a few errors in the documentation that I think should be changed. :-) 

- fixed wrong Python package name
- corrected pairing brackets in the config example
- corrected supported Nautobot version number