### PR TITLE
Default settings work on installation

### DIFF
--- a/nautobot_capacity_metrics/__init__.py
+++ b/nautobot_capacity_metrics/__init__.py
@@ -39,12 +39,12 @@ class MetricsExtConfig(PluginConfig):
     default_settings = {
         "app_metrics": {
             "models": {
-                "nautobot.dcim": {
+                "dcim": {
                     "Site": True,
                     "Rack": True,
                     "Device": True,
                 },
-                "nautobot.ipam": {"IPAddress": True, "Prefix": True},
+                "ipam": {"IPAddress": True, "Prefix": True},
             },
             "jobs": True,
             "queues": True,


### PR DESCRIPTION
Fixes #20
Fixes #21 

The default settings weren't actually working on initial installation of the plugin and didn't show the model counts. Update README as well.