### PR TITLE
Add a metric for software versions.

### DIFF
--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -270,6 +270,7 @@ PLUGINS_CONFIG = {
                 "extras": {"GitRepository": True},
             },
             "queues": True,
+            "versions": True,
         }
     },
 }

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -270,7 +270,10 @@ PLUGINS_CONFIG = {
                 "extras": {"GitRepository": True},
             },
             "queues": True,
-            "versions": True,
+            "versions": {
+                "basic": True,
+                "plugins": True,
+            },
         }
     },
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,7 +113,7 @@ The behavior of the app_metrics feature can be controlled with the following lis
 - `jobs` boolean (default **False**), publish stats about the jobs (success, warning, info, failure)
 - `queues` boolean (default **False**), publish stats about RQ Worker (nbr of worker, nbr and type of job in the different queues)
 - `models` nested dict, publish the count for a given object (Nbr Device, Nbr IP etc.. ). The first level must be the name of the module in lowercase (dcim, ipam etc..), the second level must be the name of the object (usually starting with a uppercase)
-- `plugins` nested dict, publish the versions of installed software
+- `versions` nested dict, publish the versions of installed software
 
     ```python
     PLUGINS_CONFIG = {

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,8 @@ Currently the plugin exposes these simple metrics by default:
 - Jobs stats
 - Models count (configurable via nautobot_config.py)
 
+In addition, it is possible to use the plugin configuration to expose metrics about the versions of Python, Django, Nautobot and the installed Nautobot plugins. 
+
 # Queue System Metrics Endpoint
 
 In addition to the default Nautobot system metrics which are exposed at `/metrics` which are largely centered around the Django system on which Nautobot is based this plugin provides some additional system metrics around the queuing system Nautobot uses to communicate with the Nautobot worker services.  This endpoint is provided separately via `/api/plugins/capacity-metrics/rq-metrics`, this endpoint can be scraped more frequently than the other application metrics endpoint.
@@ -111,6 +113,7 @@ The behavior of the app_metrics feature can be controlled with the following lis
 - `jobs` boolean (default **False**), publish stats about the jobs (success, warning, info, failure)
 - `queues` boolean (default **False**), publish stats about RQ Worker (nbr of worker, nbr and type of job in the different queues)
 - `models` nested dict, publish the count for a given object (Nbr Device, Nbr IP etc.. ). The first level must be the name of the module in lowercase (dcim, ipam etc..), the second level must be the name of the object (usually starting with a uppercase)
+- `plugins` nested dict, publish the versions of installed software
 
     ```python
     PLUGINS_CONFIG = {
@@ -122,6 +125,10 @@ The behavior of the app_metrics feature can be controlled with the following lis
            },
            "jobs": True,
            "queues": True,
+           "versions": {
+             "basic": True,
+             "plugins": True,
+           }
          }
        }
     }
@@ -213,6 +220,10 @@ PLUGINS = ["nautobot_capacity_metrics"]
 #                 },
 #             },
 #             "queues": True,
+#             "versions": {
+#                 "basic": True,
+#                 "plugins": True,
+#             }
 #         }
 #     },
 # }

--- a/nautobot_capacity_metrics/__init__.py
+++ b/nautobot_capacity_metrics/__init__.py
@@ -49,6 +49,7 @@ class MetricsExtConfig(PluginConfig):
             },
             "jobs": True,
             "queues": True,
+            "versions": True,
         }
     }
     caching_config = {}

--- a/nautobot_capacity_metrics/__init__.py
+++ b/nautobot_capacity_metrics/__init__.py
@@ -50,7 +50,7 @@ class MetricsExtConfig(PluginConfig):
             "jobs": True,
             "queues": True,
             "versions": {
-                "basic": True,
+                "basic": False,
                 "plugins": False,
             },
         }

--- a/nautobot_capacity_metrics/__init__.py
+++ b/nautobot_capacity_metrics/__init__.py
@@ -49,7 +49,10 @@ class MetricsExtConfig(PluginConfig):
             },
             "jobs": True,
             "queues": True,
-            "versions": True,
+            "versions": {
+                "basic": True,
+                "plugins": False,
+            },
         }
     }
     caching_config = {}

--- a/nautobot_capacity_metrics/api/views.py
+++ b/nautobot_capacity_metrics/api/views.py
@@ -10,7 +10,13 @@ import prometheus_client
 from prometheus_client.core import CollectorRegistry, GaugeMetricFamily
 
 from nautobot_capacity_metrics import __REGISTRY__
-from nautobot_capacity_metrics.metrics import collect_extras_metric, metric_jobs, metric_models, metric_rq
+from nautobot_capacity_metrics.metrics import (
+    collect_extras_metric,
+    metric_jobs,
+    metric_models,
+    metric_rq,
+    metric_versions,
+)
 
 logger = logging.getLogger(__name__)
 PLUGIN_SETTINGS = settings.PLUGINS_CONFIG["nautobot_capacity_metrics"]["app_metrics"]
@@ -33,6 +39,10 @@ class AppMetricsCollector:
 
         if "models" in PLUGIN_SETTINGS:
             for metric in metric_models(PLUGIN_SETTINGS["models"]):
+                yield metric
+
+        if "versions" in PLUGIN_SETTINGS:
+            for metric in metric_versions():
                 yield metric
 
         # --------------------------------------------------------------

--- a/nautobot_capacity_metrics/api/views.py
+++ b/nautobot_capacity_metrics/api/views.py
@@ -41,7 +41,9 @@ class AppMetricsCollector:
             for metric in metric_models(PLUGIN_SETTINGS["models"]):
                 yield metric
 
-        if "versions" in PLUGIN_SETTINGS:
+        if "versions" in PLUGIN_SETTINGS and (
+            PLUGIN_SETTINGS["versions"]["basic"] or PLUGIN_SETTINGS["versions"]["plugins"]
+        ):
             for metric in metric_versions():
                 yield metric
 

--- a/nautobot_capacity_metrics/metrics.py
+++ b/nautobot_capacity_metrics/metrics.py
@@ -1,7 +1,10 @@
 """Metrics libraries for the nautobot_capacity_metrics plugin."""
 import logging
 import importlib
+import platform
 from collections.abc import Iterable
+
+import django
 from packaging import version
 from django.conf import settings
 
@@ -117,6 +120,31 @@ def metric_models(params):
             except AttributeError:
                 logger.warning("Unable to load the module %s from the python library %s.models", model, app)
 
+    yield gauge
+
+
+def metric_versions():
+    """Return django, Nautobot, Python and app versions in Prometheus Metric format.
+
+    Return:
+        Iterator[GaugeMetricFamily]
+            nautobot_app_versions: the versions as labels
+    """
+    versions = {"python": platform.python_version(), "django": django.get_version(), "nautobot": settings.VERSION}
+
+    # Collect app versions
+    for app in settings.PLUGINS:
+        try:
+            app_module = importlib.import_module(app)
+        except ModuleNotFoundError:
+            logger.warning("Unable to find the python library %s", app)
+            continue
+        try:
+            versions[app] = app_module.__version__
+        except AttributeError:
+            logger.warning("Module %s does not have __version__ defined.", app)
+    gauge = GaugeMetricFamily("nautobot_app_versions", "Nautobot app versions", labels=versions.keys())
+    gauge.add_metric(versions.values(), 1)
     yield gauge
 
 


### PR DESCRIPTION
Comes out like this
```
# HELP nautobot_app_versions Nautobot app versions
# TYPE nautobot_app_versions gauge
nautobot_app_versions{django="3.1.14",nautobot="1.2.11",nautobot_capacity_metrics="1.1.1",python="3.7.13"} 1.0
```