### PR TITLE
Add additional fields to model count

### DIFF
--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -260,9 +260,9 @@ PLUGINS_CONFIG = {
             "jobs": True,
             "models": {
                 "dcim": {
-                    "Site": True,
-                    "Rack": True,
-                    "Device": True,
+                    "Location": ["status__name", "parent__name"],
+                    "Rack": ["location__name", "location__parent__name"],
+                    "Device": ["location__parent__name", "device_type__manufacturer__name"],
                     "Interface": True,
                     "Cable": True,
                 },

--- a/nautobot_capacity_metrics/__init__.py
+++ b/nautobot_capacity_metrics/__init__.py
@@ -41,9 +41,9 @@ class MetricsExtConfig(NautobotAppConfig):
         "app_metrics": {
             "models": {
                 "dcim": {
-                    "Site": True,
-                    "Rack": True,
-                    "Device": True,
+                    "Location": ["status__name", "parent__name"],
+                    "Rack": ["location__name", "location__parent__name"],
+                    "Device": ["location__parent__name", "device_type__manufacturer__name"],
                 },
                 "ipam": {"IPAddress": True, "Prefix": True},
             },

--- a/nautobot_capacity_metrics/tests/test_endpoints.py
+++ b/nautobot_capacity_metrics/tests/test_endpoints.py
@@ -20,5 +20,5 @@ class AppMetricEndpointTests(TestCase):
     def test_model_count_metrics(self):
         """Ensure that the model count metrics work correctly."""
         resp = self.client.get(self.app_metric_url)
-        if "TestModel" not in resp.content.decode("utf-8"):
+        if "nautobot_model_count_testmodel_total" not in resp.content.decode("utf-8"):
             self.fail("nautobot_capacity_metrics.test_models.models.TestModel does not report its count.")


### PR DESCRIPTION
# Description

This PR is a follow-up on #46 (has to be merged after that) that introduces breaking changes to the output of the model count metrics.

- The model count metric has been renamed from `nautobot_model_count` to `nautobot_model_count_${model}_total` to better align with Prometheus standards
- In addition to the basic metric, you can now specify additional fields in the configuration by which the metric should be filterable (see example below)

# Example

In this example, the site count includes the status of the site, meaning that in this example there is one site with "Active" status and one with "Decommissioning". Here is corresponding configuration that shows this off (note that you can traverse more than one relationship as in the rack example):

```
"nautobot_capacity_metrics": {
        "app_metrics": {
            "models": {
                "dcim": {
                    "Site": ["status__name", "region__name"],
                    "Rack": ["site__name", "site__region__name"],
                }
            }
        }
    }
```

```
# HELP nautobot_model_count_site_by_status_total Nautobot model count per status
# TYPE nautobot_model_count_site_by_status_total gauge
nautobot_model_count_site_by_status_total{app="dcim",status="Active"} 1.0
nautobot_model_count_site_by_status_total{app="dcim",status="Decommissioning"} 1.0
```