### PR TITLE
Release v3.2.0

### DIFF
--- a/changes/+nautobot-app-v2-4-0.housekeeping
+++ b/changes/+nautobot-app-v2-4-0.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.4.0`.

--- a/changes/+nautobot-app-v2-4-1.housekeeping
+++ b/changes/+nautobot-app-v2-4-1.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.4.1`.

--- a/changes/+nautobot-app-v2-4-2.housekeeping
+++ b/changes/+nautobot-app-v2-4-2.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.4.2`.

--- a/changes/+nautobot-app-v2.5.0.housekeeping
+++ b/changes/+nautobot-app-v2.5.0.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.5.0`.

--- a/changes/+nautobot-app-v2.5.1.housekeeping
+++ b/changes/+nautobot-app-v2.5.1.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.5.1`.

--- a/changes/+nautobot-app-v2.6.0.housekeeping
+++ b/changes/+nautobot-app-v2.6.0.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.6.0`.

--- a/changes/+nautobot-app-v2.7.0.housekeeping
+++ b/changes/+nautobot-app-v2.7.0.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.0`.

--- a/changes/+nautobot-app-v2.7.1.housekeeping
+++ b/changes/+nautobot-app-v2.7.1.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.1`.

--- a/changes/+nautobot-app-v2.7.2.housekeeping
+++ b/changes/+nautobot-app-v2.7.2.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.2`.

--- a/changes/107.dependencies
+++ b/changes/107.dependencies
@@ -1,1 +1,0 @@
-Pinned Django debug toolbar to <6.0.0.

--- a/docs/admin/release_notes/version_3.2.md
+++ b/docs/admin/release_notes/version_3.2.md
@@ -1,0 +1,27 @@
+# v3.2 Release Notes
+
+This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release Overview
+
+- Changed minimum Nautobot version to 2.4.20.
+- Dropped support for Python versions 3.8 and 3.9.
+
+<!-- towncrier release notes start -->
+## [v3.2.0 (2025-12-05)](https://github.com/nautobot/nautobot-app-capacity-metrics/releases/tag/v3.2.0)
+
+### Dependencies
+
+- [#107](https://github.com/nautobot/nautobot-app-capacity-metrics/issues/107) - Pinned Django debug toolbar to <6.0.0.
+
+### Housekeeping
+
+- Rebaked from the cookie `nautobot-app-v2.4.0`.
+- Rebaked from the cookie `nautobot-app-v2.4.1`.
+- Rebaked from the cookie `nautobot-app-v2.4.2`.
+- Rebaked from the cookie `nautobot-app-v2.5.0`.
+- Rebaked from the cookie `nautobot-app-v2.5.1`.
+- Rebaked from the cookie `nautobot-app-v2.6.0`.
+- Rebaked from the cookie `nautobot-app-v2.7.0`.
+- Rebaked from the cookie `nautobot-app-v2.7.1`.
+- Rebaked from the cookie `nautobot-app-v2.7.2`.

--- a/docs/admin/release_notes/version_3.2.md
+++ b/docs/admin/release_notes/version_3.2.md
@@ -8,7 +8,7 @@ This document describes all new features and changes in the release. The format 
 - Dropped support for Python versions 3.8 and 3.9.
 
 <!-- towncrier release notes start -->
-## [v3.2.0 (2025-12-05)](https://github.com/nautobot/nautobot-app-capacity-metrics/releases/tag/v3.2.0)
+## [v3.2.0 (2025-12-10)](https://github.com/nautobot/nautobot-app-capacity-metrics/releases/tag/v3.2.0)
 
 ### Dependencies
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,6 +117,7 @@ nav:
       - Compatibility Matrix: "admin/compatibility_matrix.md"
       - Release Notes:
           - "admin/release_notes/index.md"
+          - v3.2: "admin/release_notes/version_3.2.md"
           - v3.1: "admin/release_notes/version_3.1.md"
           - v3.0: "admin/release_notes/version_3.0.md"
           - v2.1: "admin/release_notes/version_2.1.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-capacity-metrics"
-version = "3.2.0a0"
+version = "3.2.0"
 description = "App to improve the instrumentation of Nautobot and expose additional metrics (Application Metrics, RQ Worker)."
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"
@@ -163,7 +163,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.towncrier]
 package = "nautobot_capacity_metrics"
 directory = "changes"
-filename = "docs/admin/release_notes/version_X.Y.md"
+filename = "docs/admin/release_notes/version_3.2.md"
 template = "development/towncrier_template.j2"
 start_string = "<!-- towncrier release notes start -->"
 issue_format = "[#{issue}](https://github.com/nautobot/nautobot-app-capacity-metrics/issues/{issue})"


### PR DESCRIPTION
# v3.2 Release Notes

This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## Release Overview

- Changed minimum Nautobot version to 2.4.20.
- Dropped support for Python versions 3.8 and 3.9.

## [v3.2.0 (2025-12-10)](https://github.com/nautobot/nautobot-app-capacity-metrics/releases/tag/v3.2.0)

### Dependencies

- [#107](https://github.com/nautobot/nautobot-app-capacity-metrics/issues/107) - Pinned Django debug toolbar to <6.0.0.

### Housekeeping

- Rebaked from the cookie `nautobot-app-v2.4.0`.
- Rebaked from the cookie `nautobot-app-v2.4.1`.
- Rebaked from the cookie `nautobot-app-v2.4.2`.
- Rebaked from the cookie `nautobot-app-v2.5.0`.
- Rebaked from the cookie `nautobot-app-v2.5.1`.
- Rebaked from the cookie `nautobot-app-v2.6.0`.
- Rebaked from the cookie `nautobot-app-v2.7.0`.
- Rebaked from the cookie `nautobot-app-v2.7.1`.
- Rebaked from the cookie `nautobot-app-v2.7.2`.
